### PR TITLE
Add in facebookPage to networks to fix #20

### DIFF
--- a/src/components/Map/Point.js
+++ b/src/components/Map/Point.js
@@ -10,6 +10,7 @@ class Point {
             region: network.region,
             contact: network.contact || null,
             socials: network.social || null,
+            facebookPage: network.facebookPage,
             state: network.state,
             title: network.title,
             generalForm: network.generalForm,


### PR DESCRIPTION
Facebook page was not getting passed so if an org only had a facebook page they would link to undefined as in #20 
