### PR TITLE
Add sortable table of networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "http://mutualaidhub.org/",
   "private": true,
   "dependencies": {
+    "@ant-design/icons": "^4.0.5",
     "@mapbox/geo-viewport": "^0.4.0",
     "@mapbox/mapbox-gl-geocoder": "^4.5.1",
     "@testing-library/jest-dom": "^4.2.4",

--- a/src/components/NetworksTable/index.jsx
+++ b/src/components/NetworksTable/index.jsx
@@ -1,42 +1,112 @@
 import React, { useState } from 'react'
-import { Table } from 'antd'
+import { Button, Input, Table } from 'antd'
+import { SearchOutlined } from '@ant-design/icons';
 
 import './style.scss';
 
 const NetworksTable = (props) => {
-  const [searchText, setSearchText] = useState('')
   const [searchCol, setSearchCol] = useState('')
+
+  const {
+    networks
+  } = props
+
+  const getColumnSearchProps = (dataIndex, description, secondaryDataIndex='') => ({
+    filterDropdown: ({setSelectedKeys, selectedKeys, confirm, clearFilters}) => (
+      <div style={{ padding: 8 }}>
+        <Input
+          placeholder={`Search ${description}`}
+          value={selectedKeys[0]}
+          onChange={e => setSelectedKeys(e.target.value ? [e.target.value] : [])}
+          onPressEnter={() => handleSearch(confirm, dataIndex)}
+          style={{ width: 188, marginBottom: 8, display: 'block' }}
+        />
+        <Button
+          type="primary"
+          onClick={() => handleSearch(confirm, dataIndex)}
+          icon={<SearchOutlined />}
+          size="small"
+          style={{ width: 90, marginRight: 8 }}
+        >
+          Search
+        </Button>
+        <Button onClick={clearFilters} size="small" style={{ width: 90 }}>
+          Reset
+        </Button>
+      </div>
+    ),
+    filterIcon: filtered => <SearchOutlined style={{ color: filtered ? '#1890ff' : undefined }} />,
+    onFilter: (value, record) => {
+      if (secondaryDataIndex) {
+        return (
+          record[dataIndex].toLowerCase().includes(value.toLowerCase())
+          || record[secondaryDataIndex].toLowerCase().includes(value.toLowerCase())
+        )
+      } else {
+        return record[dataIndex].toLowerCase().includes(value.toLowerCase())
+      }
+    },
+    render: text => searchCol === dataIndex && text
+  })
+
+  const handleSearch = (confirm, dataIndex) => {
+    confirm();
+    setSearchCol(dataIndex)
+  }
 
   const tableColumns = [
     {
       title: 'Organization',
+      width: '35vw',
       dataIndex: 'title',
       key: 'title',
+      sorter: (a,b) => a.title.localeCompare(b.title),
+      ...getColumnSearchProps('title', 'organizations'),
+      render: text => text,
+    },
+    {
+      title: 'Languages',
+      width: '15vw',
+      dataIndex: 'language',
+      key: 'language',
+      sorter: (a,b) => a.language.localeCompare(b.language),
+      ...getColumnSearchProps('language', 'languages'),
+      render: text => text,
+    },
+    {
+      title: 'State',
+      width: '5vw',
+      dataIndex: 'state',
+      key: 'state',
+      sorter: (a,b) => a.state.localeCompare(b.state),
+      ...getColumnSearchProps('state', 'states'),
+      render: text => text,
     },
     {
       title: 'Location',
+      width: '25vw',
       dataIndex: 'location',
       key: 'location',
+      sorter: (a,b) => a.neighborhood.localeCompare(b.neighborhood) || a.address.localeCompare(b.address),
+      ...getColumnSearchProps('address', 'locations', 'neighborhood'),
       render: (location, record) => (
         <>
           {record.neighborhood && <>{record.neighborhood}, </>}
           {record.address && <>{record.address}</>}
         </>
-        )
-    },
-    {
-      title: 'State',
-      dataIndex: 'state',
-      key: 'state',
-    },
-    {
-      title: 'Category',
-      dataIndex: 'category',
-      key: 'category',
+        ),
     },
     {
       title: 'Get involved',
+      width: '10vw',
+      filters: [
+        { text: 'General Information', value: 'generalForm'},
+        { text: 'Offer Support', value: 'supportOfferForm' },
+        { text: 'Request Support', value: 'supportRequestForm' },
+        { text: 'Community', value: 'facebookPage' },
+      ],
       dataIndex: 'forms',
+      onFilter: (value, record) => record[value],
       key: 'forms',
       render: (form, record) => (
         <ul className='resources'>
@@ -47,24 +117,15 @@ const NetworksTable = (props) => {
         </ul>
       )
     },
-    {
-      title: 'Languages',
-      dataIndex: 'language',
-      key: 'language',
-    },
   ]
-
-  const {
-    allNetworks
-  } = props
 
   return (
     <>
       <Table
         rowKey={network => network.id}
         columns={tableColumns}
-        dataSource={allNetworks}
-        pagination={{pageSize: 40, hideOnSinglePage: true}}
+        dataSource={networks}
+        pagination={{pageSize: 20, hideOnSinglePage: true}}
       />
     </>
   )

--- a/src/components/NetworksTable/index.jsx
+++ b/src/components/NetworksTable/index.jsx
@@ -1,8 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { Table } from 'antd'
+
 import './style.scss';
 
 const NetworksTable = (props) => {
+  const [searchText, setSearchText] = useState('')
+  const [searchCol, setSearchCol] = useState('')
 
   const tableColumns = [
     {
@@ -15,10 +18,10 @@ const NetworksTable = (props) => {
       dataIndex: 'location',
       key: 'location',
       render: (location, record) => (
-        <span>
+        <>
           {record.neighborhood && <>{record.neighborhood}, </>}
           {record.address && <>{record.address}</>}
-        </span>
+        </>
         )
     },
     {
@@ -36,14 +39,12 @@ const NetworksTable = (props) => {
       dataIndex: 'forms',
       key: 'forms',
       render: (form, record) => (
-        <span>
-          <ul className='resources'>
-            {record.generalForm && <li><a href={record.generalForm} target='blank'> Information </a></li>}
-            {record.supportOfferForm && <li><a href={record.supportOfferForm} target='blank'> Offer Support </a></li>}
-            {record.supportRequestForm && <li><a href={record.supportRequestForm} target='blank'> Request Support </a></li>}
-            {record.facebookPage && <li><a href={record.facebookPage} target='blank'> Social Media </a></li>}
-          </ul>
-        </span>
+        <ul className='resources'>
+          {record.generalForm && <li><a href={record.generalForm} target='blank' className='general'>Information</a></li>}
+          {record.supportOfferForm && <li><a href={record.supportOfferForm} target='blank' className='offer'>Offer Support</a></li>}
+          {record.supportRequestForm && <li><a href={record.supportRequestForm} target='blank' className='request'>Request Support</a></li>}
+          {record.facebookPage && <li><a href={record.facebookPage} target='blank' className='other'>Community</a></li>}
+        </ul>
       )
     },
     {
@@ -56,15 +57,16 @@ const NetworksTable = (props) => {
   const {
     allNetworks
   } = props
+
   return (
-    <div>
+    <>
       <Table
         rowKey={network => network.id}
         columns={tableColumns}
         dataSource={allNetworks}
         pagination={{pageSize: 40, hideOnSinglePage: true}}
       />
-    </div>
+    </>
   )
 }
 

--- a/src/components/NetworksTable/index.jsx
+++ b/src/components/NetworksTable/index.jsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react'
+import { Table } from 'antd'
+import './style.scss';
+
+const NetworksTable = (props) => {
+
+  const tableColumns = [
+    {
+      title: 'Organization',
+      dataIndex: 'title',
+      key: 'title',
+    },
+    {
+      title: 'Location',
+      dataIndex: 'location',
+      key: 'location',
+      render: (location, record) => (
+        <span>
+          {record.neighborhood && <>{record.neighborhood}, </>}
+          {record.address && <>{record.address}</>}
+        </span>
+        )
+    },
+    {
+      title: 'State',
+      dataIndex: 'state',
+      key: 'state',
+    },
+    {
+      title: 'Category',
+      dataIndex: 'category',
+      key: 'category',
+    },
+    {
+      title: 'Get involved',
+      dataIndex: 'forms',
+      key: 'forms',
+      render: (form, record) => (
+        <span>
+          <ul className='resources'>
+            {record.generalForm && <li><a href={record.generalForm} target='blank'> Information </a></li>}
+            {record.supportOfferForm && <li><a href={record.supportOfferForm} target='blank'> Offer Support </a></li>}
+            {record.supportRequestForm && <li><a href={record.supportRequestForm} target='blank'> Request Support </a></li>}
+            {record.facebookPage && <li><a href={record.facebookPage} target='blank'> Social Media </a></li>}
+          </ul>
+        </span>
+      )
+    },
+    {
+      title: 'Languages',
+      dataIndex: 'language',
+      key: 'language',
+    },
+  ]
+
+  const {
+    allNetworks
+  } = props
+  return (
+    <div>
+      <Table
+        rowKey={network => network.id}
+        columns={tableColumns}
+        dataSource={allNetworks}
+        pagination={{pageSize: 40, hideOnSinglePage: true}}
+      />
+    </div>
+  )
+}
+
+export default NetworksTable

--- a/src/components/NetworksTable/style.scss
+++ b/src/components/NetworksTable/style.scss
@@ -1,0 +1,3 @@
+.resources {
+  list-style-type:none
+}

--- a/src/components/NetworksTable/style.scss
+++ b/src/components/NetworksTable/style.scss
@@ -1,3 +1,21 @@
+$general: #8048f3;
+$offer: #6ac1e5;
+$request: #ef4822;
+$info: #057A8F;
+
 .resources {
-  list-style-type:none
+  list-style-type:none;
+  font-weight: bold;
+  .offer {
+    color: $offer;
+  }
+  .general {
+    color: $general;
+  }
+  .request {
+    color: $request;
+  }
+  .other {
+    color: $info;
+  }
 }

--- a/src/containers/DefaultLayout.js
+++ b/src/containers/DefaultLayout.js
@@ -55,7 +55,7 @@ class DefaultLayout extends React.Component {
             {/* <Menu.Item key="1">Guides and other resources</Menu.Item> */}
           </Menu>
         </Header>
-        <Content style={{ padding: '0 50px' }}>
+        {/* <Content style={{ padding: '0 50px' }}>
           <div className="main-container">
              {mapboxgl.supported() ? <>
               <Filters 
@@ -88,10 +88,18 @@ class DefaultLayout extends React.Component {
             <div className="tagline">Find Mutual Aid Networks and other community self-support projects near you. Reach out to these groups directly via the map above to get involved, offer resources, or submit needs requests.</div>
             <SubmitNetwork />
           </div>
-        </Content>
+        </Content> */}
         <Footer style={{ textAlign: 'center' }}>
           <div className="footer-text">
-            We list these networks as a public resource. We cannot verify or vouch for any network or individual offerings. Please exercise all necessary judgement when interacting with community members not previously known to you.
+            <p>
+              We list these networks as a public resource. We cannot verify or vouch for any network
+              or individual offerings. Please exercise all necessary judgement when interacting with
+              community members not previously known to you.
+            </p>
+            <p>
+              This website is brought to you by <a href="https://townhallproject.com/" target="blank">Town Hall Project</a>.
+              To report an error or other issue, please contact: <a href="mailto:info@townhallproject.com">info@townhallproject.com</a>
+            </p>
           </div>
         </Footer>
       </Layout>

--- a/src/containers/DefaultLayout.js
+++ b/src/containers/DefaultLayout.js
@@ -118,14 +118,7 @@ class DefaultLayout extends React.Component {
             <div className="tagline">Find Mutual Aid Networks and other community self-support projects near you. Reach out to these groups directly via the map above to get involved, offer resources, or submit needs requests.</div>
             <SubmitNetwork />
           </>}
-          {this.state.currentTab === 'networks' && <>
-            <Filters
-              setFilters={setFilters}
-              selectedCategories={selectedCategories}
-              visible={viewState === 'default'}
-            />
-            <NetworksTable allNetworks={filteredNetworks} />
-          </>}
+          {this.state.currentTab === 'networks' && <NetworksTable networks={allNetworks} />}
           </div>
         </Content>
         <Footer style={{ textAlign: 'center' }}>

--- a/src/containers/DefaultLayout.js
+++ b/src/containers/DefaultLayout.js
@@ -13,16 +13,29 @@ import ListView from '../components/ListView';
 
 import './style.scss';
 import NoWebGl from '../components/NoWebGl';
+import NetworksTable from '../components/NetworksTable';
 
 const { Header, Content, Footer } = Layout;
 const mapboxgl = window.mapboxgl;
 class DefaultLayout extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      currentTab: 'map'
+    }
+  }
+
   componentDidMount() {
     const {
       requestNetworks
     } = this.props;
     requestNetworks();
   }
+
+  handleNav = (e) => {
+    this.setState({currentTab: e.key})
+  }
+
   render() {
     const {
       setFilters,
@@ -46,17 +59,22 @@ class DefaultLayout extends React.Component {
     return (
       <Layout className="layout">
         <Header>
-          <div className="logo"></div>
+          <div className="logo" onClick={() => this.setState({currentTab: 'map'})}></div>
           <Menu
             theme="dark"
             mode="horizontal"
             style={{ lineHeight: '64px' }}
+            onClick={this.handleNav}
+            selectedKeys={[this.state.currentTab]}
           >
+            <Menu.Item key="map">Map</Menu.Item>
+            <Menu.Item key="networks">Networks</Menu.Item>
             {/* <Menu.Item key="1">Guides and other resources</Menu.Item> */}
           </Menu>
         </Header>
-        {/* <Content style={{ padding: '0 50px' }}>
+        <Content style={{ padding: '0 50px' }}>
           <div className="main-container">
+          {this.state.currentTab === 'map' && <>
              {mapboxgl.supported() ? <>
               <Filters 
                 setFilters={setFilters}
@@ -87,8 +105,10 @@ class DefaultLayout extends React.Component {
             
             <div className="tagline">Find Mutual Aid Networks and other community self-support projects near you. Reach out to these groups directly via the map above to get involved, offer resources, or submit needs requests.</div>
             <SubmitNetwork />
+          </>}
+          {this.state.currentTab === 'networks' && <NetworksTable allNetworks={allNetworks} />}
           </div>
-        </Content> */}
+        </Content>
         <Footer style={{ textAlign: 'center' }}>
           <div className="footer-text">
             <p>

--- a/src/containers/DefaultLayout.js
+++ b/src/containers/DefaultLayout.js
@@ -33,7 +33,19 @@ class DefaultLayout extends React.Component {
   }
 
   handleNav = (e) => {
+    const {
+      resetToDefaultView
+    } = this.props
     this.setState({currentTab: e.key})
+    resetToDefaultView()
+  }
+
+  handleLogoClick = () => {
+    const {
+      resetToDefaultView
+    } = this.props
+    this.setState({currentTab: 'map'})
+    resetToDefaultView()
   }
 
   render() {
@@ -59,7 +71,7 @@ class DefaultLayout extends React.Component {
     return (
       <Layout className="layout">
         <Header>
-          <div className="logo" onClick={() => this.setState({currentTab: 'map'})}></div>
+          <div className="logo" onClick={this.handleLogoClick}></div>
           <Menu
             theme="dark"
             mode="horizontal"
@@ -106,7 +118,14 @@ class DefaultLayout extends React.Component {
             <div className="tagline">Find Mutual Aid Networks and other community self-support projects near you. Reach out to these groups directly via the map above to get involved, offer resources, or submit needs requests.</div>
             <SubmitNetwork />
           </>}
-          {this.state.currentTab === 'networks' && <NetworksTable allNetworks={allNetworks} />}
+          {this.state.currentTab === 'networks' && <>
+            <Filters
+              setFilters={setFilters}
+              selectedCategories={selectedCategories}
+              visible={viewState === 'default'}
+            />
+            <NetworksTable allNetworks={filteredNetworks} />
+          </>}
           </div>
         </Content>
         <Footer style={{ textAlign: 'center' }}>


### PR DESCRIPTION
This PR addresses issue #24 

- Creates menu tabs for 'Map' and 'Networks'
- On the Networks tab there is a sortable and filterable table to search through all the networks
- Table paginates with 20+ entries
- Clicking on a category header will sort the row ascending, descending, and then revert to original (with an icon which indicates how it is currently sorted)
- Clicking on the search icon will allow a user to input a string and search through that category for matches. This filtering stacks and can be applied to multiple categories at once. If a column is currently filtered, the search icon highlights blue.
- Clicking on the filter icon (only the 'Get involved' column) allows filtering by form options (offer, request, etc).
- Table is responsive up to tablet width, but is not user friendly for mobile

## Initial view:
<img width="1439" alt="Screen Shot 2020-04-01 at 5 26 00 PM" src="https://user-images.githubusercontent.com/44733961/78199078-8c126980-743f-11ea-9d87-77953da0e3a9.png">


## Sorted by state and going to filter by 'Sal' in org title:
<img width="1437" alt="Screen Shot 2020-04-01 at 5 26 29 PM" src="https://user-images.githubusercontent.com/44733961/78199039-6c7b4100-743f-11ea-912e-825a625a8a77.png">



## Sorted by state and filtered by 'Sal' in title:
<img width="1439" alt="Screen Shot 2020-04-01 at 5 26 46 PM" src="https://user-images.githubusercontent.com/44733961/78198982-3938b200-743f-11ea-9b6c-40ff4e357670.png">




@meganrm 