### PR TITLE
Freeze Organization column and set the rest to scroll on mobile

### DIFF
--- a/src/components/NetworksTable/index.jsx
+++ b/src/components/NetworksTable/index.jsx
@@ -57,7 +57,8 @@ const NetworksTable = (props) => {
   const tableColumns = [
     {
       title: 'Organization',
-      width: '30vw',
+      width: '15vw',
+      fixed: 'left',
       dataIndex: 'title',
       key: 'title',
       sorter: (a,b) => a.title.localeCompare(b.title),
@@ -122,6 +123,8 @@ const NetworksTable = (props) => {
         columns={tableColumns}
         dataSource={networks}
         pagination={{pageSize: 20, hideOnSinglePage: true}}
+        scroll={{x: 768}}
+        size='small'
       />
     </>
   )


### PR DESCRIPTION
This PR improves the table view for mobile users. On screens 768px and lower, it freezes the organization column to the left and sets the others to scroll. 

### Visual on (simulated) Pixel 2
![Screen Shot 2020-04-07 at 2 30 04 PM](https://user-images.githubusercontent.com/44733961/78721403-560c3400-78dc-11ea-9f7c-99b1d1735469.png)

### Visual on (simulated) iPhone 6
![Screen Shot 2020-04-07 at 2 30 18 PM](https://user-images.githubusercontent.com/44733961/78721407-599fbb00-78dc-11ea-8033-9ef6c8f2d639.png)

@meganrm @nathanwilliams