### PR TITLE
Create side menu for mobile devices

### DIFF
--- a/src/containers/DefaultLayout.js
+++ b/src/containers/DefaultLayout.js
@@ -3,6 +3,9 @@ import {
   connect
 } from 'react-redux';
 import { Layout, Menu } from 'antd';
+import {
+  MenuFoldOutlined,
+} from '@ant-design/icons';
 
 import networkStateBranch from '../state/networks';
 import selectionStateBranch from '../state/selections';
@@ -16,13 +19,15 @@ import './style.scss';
 import NoWebGl from '../components/NoWebGl';
 import NetworksTable from '../components/NetworksTable';
 
-const { Header, Content, Footer } = Layout;
+const { Header, Content, Footer, Sider } = Layout;
 const mapboxgl = window.mapboxgl;
 class DefaultLayout extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      currentTab: 'map'
+      currentTab: 'map',
+      isMobile: false,
+      collapsed: true,
     }
   }
 
@@ -31,6 +36,12 @@ class DefaultLayout extends React.Component {
       requestNetworks
     } = this.props;
     requestNetworks();
+    this.checkIfMobile();
+    window.addEventListener('resize', this.checkIfMobile);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.checkIfMobile);
   }
 
   handleNav = (e) => {
@@ -38,15 +49,16 @@ class DefaultLayout extends React.Component {
       resetToDefaultView
     } = this.props
     this.setState({currentTab: e.key})
+    if (this.state.isMobile) this.setState({collapsed: true})
     resetToDefaultView()
   }
 
-  handleLogoClick = () => {
-    const {
-      resetToDefaultView
-    } = this.props
-    this.setState({currentTab: 'map'})
-    resetToDefaultView()
+  toggleCollapsibleMenu = () => {
+    this.setState({collapsed: !this.state.collapsed})
+  }
+
+  checkIfMobile = () => {
+    window.innerWidth <= 768 ? this.setState({isMobile: true}) : this.setState({isMobile: false})
   }
 
   render() {
@@ -71,75 +83,100 @@ class DefaultLayout extends React.Component {
     // viewState --> list or default
     return (
       <Layout className="layout">
-        <Header>
-          <div className="logo" onClick={this.handleLogoClick}></div>
-          <Menu
-            theme="dark"
-            mode="horizontal"
-            style={{ lineHeight: '64px' }}
-            onClick={this.handleNav}
-            selectedKeys={[this.state.currentTab]}
-          >
-            <Menu.Item key="map">Map</Menu.Item>
-            <Menu.Item key="networks">Table View</Menu.Item>
-            <Menu.Item key="about">About</Menu.Item>
-            {/* <Menu.Item key="1">Guides and other resources</Menu.Item> */}
-          </Menu>
-        </Header>
-        <Content style={{ padding: '0 50px' }}>
-          <div className="main-container">
-          {this.state.currentTab === 'map' && <>
-             {mapboxgl.supported() ? <>
-              <Filters 
-                setFilters={setFilters}
-                selectedCategories={selectedCategories}
-                absolute={true}
-                visible={viewState ==='default'}
-              />
-              <div className={`interactive-content-${viewState}`}>
-              <MapView
-                  networks={filteredNetworks}
-                  viewState={viewState}
-                  setLatLng={setLatLng}
-                  selectedCategories={selectedCategories}
-                  resetToDefaultView={resetToDefaultView}
-                  hoveredPointId={hoveredPointId}
-                  setHoveredPoint={setHoveredPoint}
-                  bbox={masterBbox}
-                  setUsState={setUsState}
-                /> 
-                <ListView 
-                  visibleCards={visibleCards}
-                  setHoveredPoint={setHoveredPoint}
+        {this.state.isMobile &&
+        <>
+          {this.state.collapsed ?
+          <Header onClick={this.toggleCollapsibleMenu}>
+            <MenuFoldOutlined className='menu-btn'/>
+          </Header>
+          :
+          <Sider trigger={null}>
+            <div className="logo"></div>
+            <Menu
+              theme="dark"
+              mode="inline"
+              onClick={this.handleNav}
+              selectedKeys={[this.state.currentTab]}
+            >
+              <Menu.Item key="map">Map</Menu.Item>
+              <Menu.Item key="networks">Table View</Menu.Item>
+              <Menu.Item key="about">About</Menu.Item>
+            </Menu>
+          </Sider>
+          }
+        </>}
+        <Layout>
+          {!this.state.isMobile &&
+          <Header>
+            <div className="logo" onClick={() => this.handleNav({key: 'map'})}></div>
+            <Menu
+              theme="dark"
+              mode="horizontal"
+              style={{ lineHeight: '64px' }}
+              onClick={this.handleNav}
+              selectedKeys={[this.state.currentTab]}
+            >
+              <Menu.Item key="map">Map</Menu.Item>
+              <Menu.Item key="networks">Table View</Menu.Item>
+              <Menu.Item key="about">About</Menu.Item>
+              {/* <Menu.Item key="1">Guides and other resources</Menu.Item> */}
+            </Menu>
+          </Header>}
+          <Content style={{ padding: '0 50px' }}>
+            <div className="main-container">
+            {this.state.currentTab === 'map' && <>
+              {mapboxgl.supported() ? <>
+                <Filters
                   setFilters={setFilters}
                   selectedCategories={selectedCategories}
+                  absolute={true}
+                  visible={viewState ==='default'}
                 />
-                </div>
-              </>: <NoWebGl />}
-            
-            <div className="tagline">Find Mutual Aid Networks and other community self-support projects near you. Reach out to these groups directly via the map above to get involved, offer resources, or submit needs requests.</div>
-            <SubmitNetwork />
-          </>}
-          {this.state.currentTab === 'networks' && <NetworksTable networks={allNetworks} />}
-          {this.state.currentTab === 'about' && <About />}
-          </div>
-        </Content>
-        <Footer style={{ textAlign: 'center' }}>
-          <div className="footer-text">
-            <p>
-              We list these networks as a public resource. We cannot verify or vouch for any network
-              or individual offerings. Please exercise all necessary judgement when interacting with
-              community members not previously known to you.
-            </p>
-            <p>
-              This data set is made available under the <a rel="noopener noreferrer" target="_blank" href="http://www.opendatacommons.org/licenses/pddl/1.0/">Public Domain Dedication and License v1.0</a>. 
-            </p>
-            <p>
-              This website is brought to you by <a href="https://townhallproject.com/" rel="noopener noreferrer" target="_blank" >Town Hall Project</a>.
-              To report an error or other issue, please contact: <a href="mailto:info@townhallproject.com">info@townhallproject.com</a>
-            </p>
-          </div>
-        </Footer>
+                <div className={`interactive-content-${viewState}`}>
+                <MapView
+                    networks={filteredNetworks}
+                    viewState={viewState}
+                    setLatLng={setLatLng}
+                    selectedCategories={selectedCategories}
+                    resetToDefaultView={resetToDefaultView}
+                    hoveredPointId={hoveredPointId}
+                    setHoveredPoint={setHoveredPoint}
+                    bbox={masterBbox}
+                    setUsState={setUsState}
+                  />
+                  <ListView
+                    visibleCards={visibleCards}
+                    setHoveredPoint={setHoveredPoint}
+                    setFilters={setFilters}
+                    selectedCategories={selectedCategories}
+                  />
+                  </div>
+                </>: <NoWebGl />}
+              
+              <div className="tagline">Find Mutual Aid Networks and other community self-support projects near you. Reach out to these groups directly via the map above to get involved, offer resources, or submit needs requests.</div>
+              <SubmitNetwork />
+            </>}
+            {this.state.currentTab === 'networks' && <NetworksTable networks={allNetworks} />}
+            {this.state.currentTab === 'about' && <About />}
+            </div>
+          </Content>
+          <Footer style={{ textAlign: 'center' }}>
+            <div className="footer-text">
+              <p>
+                We list these networks as a public resource. We cannot verify or vouch for any network
+                or individual offerings. Please exercise all necessary judgement when interacting with
+                community members not previously known to you.
+              </p>
+              <p>
+                This data set is made available under the <a rel="noopener noreferrer" target="_blank" href="http://www.opendatacommons.org/licenses/pddl/1.0/">Public Domain Dedication and License v1.0</a>. 
+              </p>
+              <p>
+                This website is brought to you by <a href="https://townhallproject.com/" rel="noopener noreferrer" target="_blank" >Town Hall Project</a>.
+                To report an error or other issue, please contact: <a href="mailto:info@townhallproject.com">info@townhallproject.com</a>
+              </p>
+            </div>
+          </Footer>
+        </Layout>
       </Layout>
     );
   }

--- a/src/containers/style.scss
+++ b/src/containers/style.scss
@@ -17,6 +17,28 @@
             background: #27a4b585;
         }
     }
+    .menu-btn {
+        color: white;
+    }
+}
+
+.ant-layout-sider {
+    .logo {
+        width: 145px;
+        height: 50px;
+        float: left;
+        color: white;
+        font-weight: 900;
+        background-image: url('../assets/logo-transparent.png');
+        background-size: contain;
+    }
+    background: #057A8F;
+    .ant-menu-dark {
+        background: #057A8F;
+        .ant-menu-item-selected {
+            background-color: #27a4b585;
+        }
+    }
 }
 
 .ant-layout-content {


### PR DESCRIPTION
Creates a side menu for mobile/small screen devices. Once a tab is clicked, the menu automatically hides as it navigates to the new view. The side menu is created by adding in a Sider that conditionally shows if the device is mobile (small).

@meganrm @nathanwilliams

### Simulated iPhone X:
![Screen Shot 2020-04-07 at 8 51 48 PM](https://user-images.githubusercontent.com/44733961/78743340-35130580-7913-11ea-9915-a009cecce696.png)
![Screen Shot 2020-04-07 at 8 52 07 PM](https://user-images.githubusercontent.com/44733961/78743346-380df600-7913-11ea-944a-9ab0c93b2600.png)
![Screen Shot 2020-04-07 at 8 42 12 PM](https://user-images.githubusercontent.com/44733961/78743349-39d7b980-7913-11ea-9342-7fef7237d8de.png)
