### PR TITLE
Add url routing, abstract menu into NavMenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-redux": "^7.2.0",
+    "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.0",
     "redux": "^4.0.5",
     "redux-logic": "^2.1.1",

--- a/src/components/NavMenu/index.jsx
+++ b/src/components/NavMenu/index.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Menu } from 'antd';
+import { NavLink } from "react-router-dom";
+
+const NavMenu = (props) => {
+  const {
+    handleNav,
+    mode,
+  } = props
+  return (
+    <>
+      <div className="logo"></div>
+      <Menu
+        theme='dark'
+        style={{ lineHeight: '64px' }}
+        mode={mode}
+        onClick={handleNav}
+        selectedKeys={[window.location.pathname]}
+      >
+        <Menu.Item key="/">
+          <NavLink to='/' exact>Map</NavLink>
+        </Menu.Item>
+        <Menu.Item key="/table-view">
+          <NavLink to='/table-view' exact>Table View</NavLink>
+        </Menu.Item>
+        <Menu.Item key="/resources">
+          <NavLink to='/resources' exact>Guides and Resources</NavLink>
+        </Menu.Item>
+        <Menu.Item key="/about">
+          <NavLink to='/about' exact>About</NavLink>
+        </Menu.Item>
+      </Menu>
+    </>
+  )
+}
+
+export default NavMenu

--- a/src/containers/DefaultLayout.js
+++ b/src/containers/DefaultLayout.js
@@ -2,7 +2,12 @@ import React from 'react';
 import {
   connect
 } from 'react-redux';
-import { Layout, Menu } from 'antd';
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+} from "react-router-dom";
+import { Layout } from 'antd';
 import {
   MenuFoldOutlined,
 } from '@ant-design/icons';
@@ -15,6 +20,7 @@ import Filters from '../components/Filters';
 import ListView from '../components/ListView';
 import About from '../components/About';
 import Resources from '../components/Resources'
+import NavMenu from '../components/NavMenu'
 
 import './style.scss';
 import NoWebGl from '../components/NoWebGl';
@@ -26,7 +32,6 @@ class DefaultLayout extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      currentTab: 'map',
       isMobile: false,
       collapsed: true,
     }
@@ -49,9 +54,8 @@ class DefaultLayout extends React.Component {
     const {
       resetToDefaultView
     } = this.props
-    this.setState({currentTab: e.key})
-    if (this.state.isMobile) this.setState({collapsed: true})
-    resetToDefaultView()
+    if (this.state.isMobile) this.setState({collapsed: true});
+    resetToDefaultView();
   }
 
   toggleCollapsibleMenu = () => {
@@ -83,107 +87,102 @@ class DefaultLayout extends React.Component {
     }
     // viewState --> list or default
     return (
-      <Layout className="layout">
-        {this.state.isMobile &&
-        <>
-          {this.state.collapsed ?
-          <Header onClick={this.toggleCollapsibleMenu}>
-            <MenuFoldOutlined className='menu-btn'/>
-          </Header>
-          :
-          <Sider trigger={null}>
-            <div className="logo"></div>
-            <Menu
-              theme="dark"
-              mode="inline"
-              onClick={this.handleNav}
-              selectedKeys={[this.state.currentTab]}
-            >
-              <Menu.Item key="map">Map</Menu.Item>
-              <Menu.Item key="networks">Table View</Menu.Item>
-              <Menu.Item key="resources">Guides and Resources</Menu.Item>
-              <Menu.Item key="about">About</Menu.Item>
-            </Menu>
-          </Sider>
-          }
-        </>}
-        <Layout>
-          {!this.state.isMobile &&
-          <Header>
-            <div className="logo" onClick={() => this.handleNav({key: 'map'})}></div>
-            <Menu
-              theme="dark"
-              mode="horizontal"
-              style={{ lineHeight: '64px' }}
-              onClick={this.handleNav}
-              selectedKeys={[this.state.currentTab]}
-            >
-              <Menu.Item key="map">Map</Menu.Item>
-              <Menu.Item key="networks">Table View</Menu.Item>
-              <Menu.Item key="resources">Guides and Resources</Menu.Item>
-              <Menu.Item key="about">About</Menu.Item>
-            </Menu>
-          </Header>}
-          <Content style={{ padding: '0 50px' }}>
-            <div className="main-container">
-            {this.state.currentTab === 'map' && <>
-              {mapboxgl.supported() ? <>
-                <Filters
-                  setFilters={setFilters}
-                  selectedCategories={selectedCategories}
-                  absolute={true}
-                  visible={viewState ==='default'}
-                />
-                <div className={`interactive-content-${viewState}`}>
-                <MapView
-                    networks={filteredNetworks}
-                    viewState={viewState}
-                    setLatLng={setLatLng}
-                    selectedCategories={selectedCategories}
-                    resetToDefaultView={resetToDefaultView}
-                    hoveredPointId={hoveredPointId}
-                    setHoveredPoint={setHoveredPoint}
-                    bbox={masterBbox}
-                    setUsState={setUsState}
-                  />
-                  <ListView
-                    visibleCards={visibleCards}
-                    setHoveredPoint={setHoveredPoint}
-                    setFilters={setFilters}
-                    selectedCategories={selectedCategories}
-                  />
-                  </div>
-                </>: <NoWebGl />}
-              
-              <div className="tagline">Find Mutual Aid Networks and other community self-support projects near you. Reach out to these groups directly via the map above to get involved, offer resources, or submit needs requests.</div>
-              <SubmitButton
-                link='https://docs.google.com/forms/d/e/1FAIpQLScuqQtCdKsDzvTzaA2PMyVHX7xcOqbOW7N7l_0YJASV4wMBVQ/viewform'
-                description='Submit a Mutual Aid Network'
+      <Router>
+        <Layout className="layout">
+          {this.state.isMobile &&
+          <>
+            {this.state.collapsed ?
+            <Header onClick={this.toggleCollapsibleMenu}>
+              <MenuFoldOutlined className='menu-btn'/>
+            </Header>
+            :
+            <Sider trigger={null}>
+              <NavMenu
+                mode='inline'
+                handleNav={this.handleNav}
               />
-            </>}
-            {this.state.currentTab === 'networks' && <NetworksTable networks={allNetworks} />}
-            {this.state.currentTab === 'about' && <About />}
-            {this.state.currentTab === 'resources' && <Resources />}
-            </div>
-          </Content>
-          <Footer style={{ textAlign: 'center' }}>
-            <div className="footer-text">
-              <p>
-                We list these networks as a public resource. We cannot verify or vouch for any network
-                or individual offerings. Please exercise all necessary judgement when interacting with
-                community members not previously known to you.
-              </p>
-              <p>
-                This data set is made available under the <a rel="noopener noreferrer" target="_blank" href="http://www.opendatacommons.org/licenses/pddl/1.0/">Public Domain Dedication and License v1.0</a>. 
-              </p>
-              <p>
-                This website is brought to you by <a href="https://townhallproject.com/" rel="noopener noreferrer" target="_blank" >Town Hall Project</a>.
-                To report an error or other issue, please contact: <a href="mailto:info@townhallproject.com">info@townhallproject.com</a>
-              </p>
-            </div>
-          </Footer>
+            </Sider>
+            }
+          </>}
+          <Layout>
+            {!this.state.isMobile &&
+            <Header>
+              <NavMenu
+                mode='horizontal'
+                handleNav={this.handleNav}
+              />
+            </Header>}
+            <Content style={{ padding: '0 50px' }}>
+              <div className="main-container">
+                <Switch>
+                  <Route path='/table-view'>
+                    <NetworksTable networks={allNetworks} />
+                  </Route>
+                  <Route path='/about'>
+                    <About />
+                  </Route>
+                  <Route path='/resources'>
+                    <Resources />
+                  </Route>
+                  <Route path='/'>
+                    {mapboxgl.supported() ? <>
+                      <Filters
+                        setFilters={setFilters}
+                        selectedCategories={selectedCategories}
+                        absolute={true}
+                        visible={viewState ==='default'}
+                      />
+                      <div className={`interactive-content-${viewState}`}>
+                        <MapView
+                          networks={filteredNetworks}
+                          viewState={viewState}
+                          setLatLng={setLatLng}
+                          selectedCategories={selectedCategories}
+                          resetToDefaultView={resetToDefaultView}
+                          hoveredPointId={hoveredPointId}
+                          setHoveredPoint={setHoveredPoint}
+                          bbox={masterBbox}
+                          setUsState={setUsState}
+                        />
+                        <ListView
+                          visibleCards={visibleCards}
+                          setHoveredPoint={setHoveredPoint}
+                          setFilters={setFilters}
+                          selectedCategories={selectedCategories}
+                        />
+                      </div>
+                    </>: <NoWebGl />}
+                    <div className="tagline">
+                      Find Mutual Aid Networks and other community self-support projects near you. Reach out to these
+                      groups directly via the map above to get involved, offer resources, or submit needs requests.
+                    </div>
+                    <SubmitButton
+                      link='https://docs.google.com/forms/d/e/1FAIpQLScuqQtCdKsDzvTzaA2PMyVHX7xcOqbOW7N7l_0YJASV4wMBVQ/viewform'
+                      description='Submit a Mutual Aid Network'
+                    />
+                  </Route>
+                </Switch>
+              </div>
+            </Content>
+            <Footer style={{ textAlign: 'center' }}>
+              <div className="footer-text">
+                <p>
+                  We list these networks as a public resource. We cannot verify or vouch for any network
+                  or individual offerings. Please exercise all necessary judgement when interacting with
+                  community members not previously known to you.
+                </p>
+                <p>
+                  This data set is made available under the <a rel="noopener noreferrer" target="_blank" href="http://www.opendatacommons.org/licenses/pddl/1.0/">Public Domain Dedication and License v1.0</a>.
+                </p>
+                <p>
+                  This website is brought to you by <a href="https://townhallproject.com/" rel="noopener noreferrer" target="_blank" >Town Hall Project</a>.
+                  To report an error or other issue, please contact: <a href="mailto:info@townhallproject.com">info@townhallproject.com</a>
+                </p>
+              </div>
+            </Footer>
+          </Layout>
         </Layout>
-      </Layout>
+      </Router>
     );
   }
 }


### PR DESCRIPTION
This PR addresses issue #67 

-Uses React Router/Browser Router to create dedicated urls for the /about, /resources, and /table-view pages
-abstracts the nav menu into its own reusable component

<img width="1092" alt="Screen Shot 2020-04-15 at 10 49 39 AM" src="https://user-images.githubusercontent.com/44733961/79370046-d9dea580-7f06-11ea-911b-040900c83f69.png">

@meganrm