### PR TITLE
Hotline Numbers

### DIFF
--- a/src/components/Map/index.jsx
+++ b/src/components/Map/index.jsx
@@ -150,10 +150,20 @@ class MapView extends React.Component {
           link = `<a rel="noopener noreferrer" href=${properties.facebookPage}>Link to group</a>`;
         }
         let location = properties.city ? `${properties.city}, ${properties.state}` : properties.state;
+        console.log(properties.hotlineNumber)
+
+        const standardizeNumber = (hotlineNumber) => {
+          let cleaned = ('' + hotlineNumber).replace(/\D/g, '')
+          let match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/)
+          return match ? `(${match[1]}) ${match[2]}-${match[3]}` : ''
+        }
+
+        const hotline = standardizeNumber(properties.hotlineNumber)
         return this.hoveredPopup.setLngLat(feature.geometry.coordinates)
           .setHTML(`
             <h4>${properties.title}</h4>
             <div>${location}</div>
+            <div>${hotline}</div>
             <div>${link}</div>`)
 
           .addTo(map);

--- a/src/components/Map/index.jsx
+++ b/src/components/Map/index.jsx
@@ -16,6 +16,7 @@ import {
   accessToken,
   mapboxStyle
 } from './constants';
+import { standardizePhoneNumber } from '../../utils/index'
 
 const mapboxgl = window.mapboxgl;
 
@@ -150,20 +151,12 @@ class MapView extends React.Component {
           link = `<a rel="noopener noreferrer" href=${properties.facebookPage}>Link to group</a>`;
         }
         let location = properties.city ? `${properties.city}, ${properties.state}` : properties.state;
-        console.log(properties.hotlineNumber)
 
-        const standardizeNumber = (hotlineNumber) => {
-          let cleaned = ('' + hotlineNumber).replace(/\D/g, '')
-          let match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/)
-          return match ? `(${match[1]}) ${match[2]}-${match[3]}` : ''
-        }
-
-        const hotline = standardizeNumber(properties.hotlineNumber)
         return this.hoveredPopup.setLngLat(feature.geometry.coordinates)
           .setHTML(`
             <h4>${properties.title}</h4>
             <div>${location}</div>
-            <div>${hotline}</div>
+            <div>${standardizePhoneNumber(properties.hotlineNumber)}</div>
             <div>${link}</div>`)
 
           .addTo(map);

--- a/src/components/NetworkCard/index.js
+++ b/src/components/NetworkCard/index.js
@@ -4,6 +4,7 @@ import {
   Row
 } from 'antd';
 import './style.scss';
+import { standardizePhoneNumber } from '../../utils/index'
 
 
 const NetworkCard = (props) => {
@@ -15,7 +16,7 @@ const NetworkCard = (props) => {
         title,
         neighborhood,
         facebookPage,
-        category,
+        hotlineNumber,
         community,
         language,
         generalForm,
@@ -44,6 +45,7 @@ const NetworkCard = (props) => {
               {neighborhood && <li>{neighborhood}</li>}
               {address && <li>{address}</li>}
             </>}
+            {hotlineNumber && <li>{standardizePhoneNumber(hotlineNumber)}</li>}
             {language && <li>{language}</li>}
             {community && <li>{community}</li>}
           </ul>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,8 @@
 export const makeConstant = (branchOfState, actionType) => `${branchOfState}-${actionType}`;
 
+export const standardizePhoneNumber = (hotlineNumber) => {
+  let cleaned = ('' + hotlineNumber).replace(/\D/g, '')
+  let match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/)
+  return match ? `(${match[1]}) ${match[2]}-${match[3]}` : ''
+}
+

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,9 @@
 export const makeConstant = (branchOfState, actionType) => `${branchOfState}-${actionType}`;
 
 export const standardizePhoneNumber = (hotlineNumber) => {
+  // returns the input as is if the field value includes notes (ie, multiple phone numbers)
+  if (hotlineNumber.length > 14) return hotlineNumber
   let cleaned = ('' + hotlineNumber).replace(/\D/g, '')
   let match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/)
   return match ? `(${match[1]}) ${match[2]}-${match[3]}` : ''
 }
-


### PR DESCRIPTION
This PR addresses issue #45.

@nathanmwilliams @meganrm 

Adds the hotline number, when present, to the popovers and network cards. The numbers are also standardized to always format in to (555) 555-5555, as long as the input contains one 9 digit number. If the input is a long value (over 14 characters), it is assumed the user included notes along with the number, and everything included is returned as is.

## Sample

### Popover
![Screen Shot 2020-04-21 at 6 40 21 PM](https://user-images.githubusercontent.com/44733961/79931515-095a4a00-8400-11ea-8f9a-71b218a1f9b0.png)

### Network Card
![Screen Shot 2020-04-21 at 6 34 31 PM](https://user-images.githubusercontent.com/44733961/79931524-0cedd100-8400-11ea-858d-0979368e3bd9.png)
