### PR TITLE
Add privacy policy

### DIFF
--- a/src/components/PageFooter/index.jsx
+++ b/src/components/PageFooter/index.jsx
@@ -19,6 +19,9 @@ const PageFooter = (props) => {
           This website is brought to you by <a href="https://townhallproject.com/" rel="noopener noreferrer" target="_blank" >Town Hall Project</a>.
           To report an error or other issue, please contact: <a href="mailto:info@townhallproject.com">info@townhallproject.com</a>
         </p>
+        <p>
+          <a href="/site-information">Privacy Policy</a>
+        </p>
       </div>
     </Footer>
   )

--- a/src/components/PrivacyPolicy/index.jsx
+++ b/src/components/PrivacyPolicy/index.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+const PrivacyPolicy = (props) => {
+  return (
+    <div className='page-container'>
+      <div className='privacy-policy'>
+        <h2 className='title'>PrivacyPolicy</h2>
+        <p>Information about your use of this website is collected using Google Analytics. The collected information consists of the following:</p>
+        <ul>
+          <li>
+            The IP address from which you access the website
+          </li>
+          <li>
+            The type of browser and operating system you use to access our site
+          </li>
+          <li>
+            The date and time you access our sit
+          </li>
+          <li>
+            The pages you visit
+          </li>
+          <li>
+            The addresses of pages from where you followed a link to our site
+          </li>
+        </ul>
+        <p>
+          Part of this information is gathered using a tracking cookie set by the Google Analytics service
+          and handled by Google as described in the Google privacy policy. See your browser documentation for
+          instructions on how to disable the cookie if you prefer not to share this data with Google.
+        </p>
+        <p>
+          We use the gathered information to help us make our site more useful to visitors and to better
+          understand how and when our site is used. We do not track or collect personally identifiable
+          information or associate gathered data with any personally identifying information from other sources.
+        </p>
+        <p>
+          By using this website, you consent to the collection of this data in the manner and for the purpose described above.
+        </p>
+        <h3>User-Submitted Data</h3>
+        <p>
+          This website may use Google or other forms to collect data from the user. All data collected will be
+          used in accordance with instructions on the intake form. If you do not wish your data displayed, contact
+          <a href="mailto:info@townhallproject.com"> info@townhallproject.com</a> to have it removed.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default PrivacyPolicy

--- a/src/components/PrivacyPolicy/index.jsx
+++ b/src/components/PrivacyPolicy/index.jsx
@@ -4,7 +4,7 @@ const PrivacyPolicy = (props) => {
   return (
     <div className='page-container'>
       <div className='privacy-policy'>
-        <h2 className='title'>PrivacyPolicy</h2>
+        <h2 className='title'>Privacy Policy</h2>
         <p>Information about your use of this website is collected using Google Analytics. The collected information consists of the following:</p>
         <ul>
           <li>

--- a/src/containers/DefaultLayout.js
+++ b/src/containers/DefaultLayout.js
@@ -22,6 +22,7 @@ import About from '../components/About';
 import Resources from '../components/Resources'
 import NavMenu from '../components/NavMenu'
 import PageFooter from '../components/PageFooter'
+import PrivacyPolicy from '../components/PrivacyPolicy'
 
 import './style.scss';
 import NoWebGl from '../components/NoWebGl';
@@ -131,6 +132,9 @@ class DefaultLayout extends React.Component {
                   </Route>
                   <Route path='/resources'>
                     <Resources />
+                  </Route>
+                  <Route path='/site-information'>
+                    <PrivacyPolicy />
                   </Route>
                   <Route path='/'>
                     {mapboxgl.supported() ? <>

--- a/src/containers/style.scss
+++ b/src/containers/style.scss
@@ -82,9 +82,10 @@ $info: #057A8F;
             }
         }
         .page-container {
-            padding: 50px;
-            width: 70vw;
+            padding: 50px 30px 50px 30px;
+            width: 90vw;
             min-width: 300px;
+            max-width: 1200px;
             margin: auto;
             a {
                 color: $offer
@@ -96,6 +97,14 @@ $info: #057A8F;
                 padding-top: 30px;
                 font-size: 1.3em;
                 font-weight: 400;
+            }
+            .privacy-policy {
+                p {
+                    padding-top: 15px;
+                }
+                h3 {
+                    padding-top: 30px;
+                }
             }
         }
         .tagline {


### PR DESCRIPTION
This PR adresses issue #50 

Create a privacy policy page, which is linked to in the site footer:
- the page is treated as a route and given /site-information as its pathname
- the page is not included in the menu page options, but is linked to in the page footer, which is found on every page, including the privacy policy page

### Page view
![Screen Shot 2020-05-03 at 2 49 19 PM](https://user-images.githubusercontent.com/44733961/80926645-4ce07c80-8d4d-11ea-9bbb-76ec9d1e8c3d.png)


### Footer with link
![Screen Shot 2020-05-03 at 2 38 39 PM](https://user-images.githubusercontent.com/44733961/80926432-2110c700-8d4c-11ea-9c6b-7b77c02dffda.png)

@meganrm 
