### PR TITLE
Add community column, remove whitespace and unused code

### DIFF
--- a/src/components/NetworksTable/index.jsx
+++ b/src/components/NetworksTable/index.jsx
@@ -11,7 +11,7 @@ const NetworksTable = (props) => {
     networks
   } = props
 
-  const getColumnSearchProps = (dataIndex, description, secondaryDataIndex='') => ({
+  const getColumnSearchProps = (dataIndex, description) => ({
     filterDropdown: ({setSelectedKeys, selectedKeys, confirm, clearFilters}) => (
       <div style={{ padding: 8 }}>
         <Input
@@ -37,14 +37,7 @@ const NetworksTable = (props) => {
     ),
     filterIcon: filtered => <SearchOutlined style={{ color: filtered ? '#1890ff' : undefined }} />,
     onFilter: (value, record) => {
-      if (secondaryDataIndex) {
-        return (
-          record[dataIndex].toLowerCase().includes(value.toLowerCase())
-          || record[secondaryDataIndex].toLowerCase().includes(value.toLowerCase())
-        )
-      } else {
-        return record[dataIndex].toLowerCase().includes(value.toLowerCase())
-      }
+      return record[dataIndex].toLowerCase().includes(value.toLowerCase())
     },
     render: text => searchCol === dataIndex && text
   })
@@ -67,7 +60,7 @@ const NetworksTable = (props) => {
     },
     {
       title: 'City',
-      width: '20vw',
+      width: '15vw',
       dataIndex: 'city',
       key: 'city',
       sorter: (a,b) => a.city.localeCompare(b.city),
@@ -82,6 +75,15 @@ const NetworksTable = (props) => {
       sorter: (a,b) => a.state.localeCompare(b.state),
       defaultSortOrder: 'ascend',
       ...getColumnSearchProps('state', 'states'),
+      render: text => text,
+    },
+    {
+      title: 'Communities',
+      width: '20vw',
+      dataIndex: 'community',
+      key: 'community',
+      sorter: (a,b) => a.community.localeCompare(b.community),
+      ...getColumnSearchProps('community', 'communities'),
       render: text => text,
     },
     {
@@ -105,7 +107,7 @@ const NetworksTable = (props) => {
       dataIndex: 'forms',
       onFilter: (value, record) => record[value],
       key: 'forms',
-      render: (form, record) => (
+      render: (text, record) => (
         <ul key="resources" className='resources'>
           {record.generalForm && <li key={`${record.generalForm}-general`} className="form-link"><Button ghost href={record.generalForm} target='blank' className='general'>General</Button></li>}
           {record.supportOfferForm && <li key={`${record.supportOfferForm}-offer`} className="form-link"><Button ghost href={record.supportOfferForm} target='blank' className='offer'>Offer Support</Button></li>}
@@ -123,8 +125,9 @@ const NetworksTable = (props) => {
         columns={tableColumns}
         dataSource={networks}
         pagination={{pageSize: 20, hideOnSinglePage: true}}
-        scroll={{x: 768}}
+        scroll={{x: 1080}}
         size='small'
+        locale={{filterConfirm: 'Filter'}}
       />
     </>
   )

--- a/src/components/NetworksTable/style.scss
+++ b/src/components/NetworksTable/style.scss
@@ -21,6 +21,7 @@ $info: #057A8F;
 .resources {
   list-style-type:none;
   font-weight: bold;
+  padding-left: 0;
   .offer {
     @include link-button($offer)
   }


### PR DESCRIPTION
This PR addresses issue #31 while also cleaning up some of the unused code in the networks table. To accommodate for the additional column, the breakpoint for horizontal scroll is updated to 1080. Additionally, left padding is removed from the get involved column, for a better mobile experience.

### Desktop
<img width="1380" alt="Screen Shot 2020-06-02 at 10 13 32 PM" src="https://user-images.githubusercontent.com/44733961/83598385-76442200-a51e-11ea-9af1-6537db76c4fc.png">

### Mobile
<img width="357" alt="Screen Shot 2020-06-02 at 10 15 15 PM" src="https://user-images.githubusercontent.com/44733961/83598454-9a9ffe80-a51e-11ea-8667-20280f471ee4.png">


@meganrm 